### PR TITLE
add clarification to ubisys C4 raw config docs

### DIFF
--- a/docs/devices/C4.md
+++ b/docs/devices/C4.md
@@ -200,6 +200,7 @@ By publishing to `zigbee2mqtt/FRIENDLY_NAME/set` the following device attributes
 For further details on these attributes please take a look at the
 [ubisys C4 Technical Reference Manual](https://www.ubisys.de/wp-content/uploads/ubisys-c4-technical-reference.pdf),
 chapter "7.8.5. Device Setup Cluster (Server)" (or the respective ubisys reference manual of the device in use in case it's not a C4) and the "ZigBee Device Physical Input Configurations Integrator's Guide" (which can be obtained directly from ubisys upon request).
+Each element in the `input_configurations` and `input_actions` arrays corresponds to a single byte. Therefore, fields longer than one byte (e.g. the "ClusterID" field in `input_actions`) are represented by multiple elements in the array, and the arrays may vary in length depending on the configuration being sent.
 
 Please note that there seems to be a size limit on the amount of data that can successfully be written to `input_actions`, so not all configurations theoretically possbile might work in reality.
 


### PR DESCRIPTION
Add a clarification to the raw configuration documentation for the Ubisys C4. Specifically, spelling out the fact that each array element corresponds to a single byte, rather than a field (which can be multiple bytes long, and around which the technical reference from Ubisys is oriented).

In my opinion, also adding an explanation of each element of one of the arrays from the example configuration would be very helpful, though I didn't add this yet, since I wasn't sure how verbose the documentation should be, or if it's preferred that users rely more heavily on the manufacturer's technical reference and use the z2m documentation more as a hint. If such an example is desired, I'd be happy to add one.